### PR TITLE
The full package...

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -23,6 +23,7 @@ The themes
 Installation
 ------------
 
+    git clone git@github.com:jbrennan/xcode4themes.git
     mkdir -p ~/Library/Developer/Xcode/UserData/FontAndColorThemes/
     cp *.dvtcolortheme ~/Library/Developer/Xcode/UserData/FontAndColorThemes/
 


### PR DESCRIPTION
I like the idea of adding a `git clone` to the code installation instructions -- it gives it the complete package installation as opposed to the _assumption_ it's already been cloned/whatever.

Your decision, however.
